### PR TITLE
add empty `test` script so CI passes by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "lint": "eslint . && prettier --check .",
     "lint:fix": "eslint --fix . && prettier --write .",
+    "test": "# TODO: add a test runner",
     "prepare": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
Don't want to decide on a test runner now (will probably use node's built-in runner for backend and vitest for frontend), but CI should still pass please!